### PR TITLE
Htmlbook.ru/css was obsolete at the moment

### DIFF
--- a/_posts/2016-2-11-Lesson-1.md
+++ b/_posts/2016-2-11-Lesson-1.md
@@ -7,7 +7,7 @@ title: Первое занятие. Что почитать
 1. [Атом - текстовый редактор](https://atom.io/)  и [полезные плагины для него](https://ymatuhin.ru/tools/atom_packages_1/)
 2. [Github - хранилище кода](https://github.com/)
 3. [Htmlbook.ru - полезный сайт если вы только начинаете изучать html](http://htmlbook.ru/)
-4. [htmlbook.ru/css - все возможные стили css](http://htmlbook.ru/css)
+5. [webref.ru/css - все возможные стили css](https://webref.ru/css)
 5. [Про CSS анимации](https://learn.javascript.ru/css-transitions)
 6. [Учебник по JS](https://learn.javascript.ru/)
 7. [Консоль браузера и как с ней работать](https://learn.javascript.ru/debugging-chrome)


### PR DESCRIPTION
webref.ru/css is actual. Proof: http://htmlbook.ru/css/transform (Актуальная версия справочника CSS теперь находится на сайте WebReference.ru)
